### PR TITLE
Remove non-existing nationcred repo from config

### DIFF
--- a/config/plugins/sourcecred/github/config.json
+++ b/config/plugins/sourcecred/github/config.json
@@ -19,7 +19,6 @@
         "nation3/n3bi",
         "nation3/nation3-template",
         "nation3/nation-drop",
-        "nation3/nationcred",
         "nation3/nationcred-contracts",
         "nation3/nationcred-datasets",
         "nation3/redirects",


### PR DESCRIPTION
The `nation3/nationcred` repo was previously renamed to `nation3/sourcecred`.

Removing it to prevent `yarn load` from hanging.