### PR TITLE
fix pr error during distribute-grain job

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -43,9 +43,7 @@ jobs:
         run: |
           echo "PULL_REQUEST_TITLE=Scheduled grain distribution for week ending $(date +"%B %dth, %Y")" >> $GITHUB_ENV
           description="This PR was auto-generated on $(date +%d-%m-%Y) \
-            to add the latest grain distribution to our instance.
-
-            $(cat grain_output.txt)"
+            to add the latest grain distribution to our instance."
           description="${description//'%'/'%25'}"
           description="${description//$'\n'/'%0A'}"
           description="${description//$'\r'/'%0D'}"


### PR DESCRIPTION
Exclude `grain_output.txt` from PR body.

Solves error:
```
Validation Failed: {"resource":"Issue","code":"custom","field":"body","message":"body is too long (maximum is 65536 characters)"}
```