### PR TITLE
fix: heap out of memory

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -15,7 +15,7 @@ jobs:
   distribute-grain:
     runs-on: ubuntu-latest
     env:
-      NODE_OPTIONS: --max_old_space_size=8192
+      NODE_OPTIONS: --max_old_space_size=14000
     steps:
       - uses: actions/checkout@v3.3.0
 


### PR DESCRIPTION
Fix out of memory error:
```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

Adjust value to match the one used in https://github.com/nation3/sourcecred-instance/blob/main/.github/workflows/generate-instance.yml#L15